### PR TITLE
12.07.2018 Version 0.1.66

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+12.07.2018 Version 0.1.66
+Default input parameter creation for file is changed from "file(param)" to "Channel.fromPath(param)"
+
 11.07.2018 Version 0.1.65
 Condition dependent type of forms added by using header script
 

--- a/js/nextflowText.js
+++ b/js/nextflowText.js
@@ -341,7 +341,7 @@ function InputParameters(id, currgid) {
                     firstPartTemp = 'if (!params.' + inputParamName + '){params.' + inputParamName + ' = ""} \n'
 
                     if (qual === "file") {
-                        secPartTemp = channelName + " = " + "file(params." + inputParamName + ") \n"
+                        secPartTemp = channelName + " = " + "Channel.fromPath(params." + inputParamName + ") \n"
                         firstPart = firstPart + firstPartTemp
                         secPart = secPart + secPartTemp
                         break


### PR DESCRIPTION
Default input parameter creation for file is changed from "file(param)" to "Channel.fromPath(param)"